### PR TITLE
Changed Ruby's and Python's keys

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -21,11 +21,11 @@
     },
     "ruby": {
         "title": "Ruby",
-        "key": "ruby"
+        "key": "rb"
     },
     "python": {
         "title": "Python",
-        "key": "python"
+        "key": "py"
     },
     "php": {
         "title": "php",


### PR DESCRIPTION
Changed the keys for Ruby and Python from just their names to their actual extensions. The vast majority of files written in Ruby and Python use the .rb and .py extensions rather than .ruby and .python.